### PR TITLE
Update for python-can v4

### DIFF
--- a/For Linux Raspbian Ubuntu/software/python3/receive.py
+++ b/For Linux Raspbian Ubuntu/software/python3/receive.py
@@ -25,7 +25,7 @@ import can
 os.system('sudo ip link set can0 type can bitrate 1000000')
 os.system('sudo ifconfig can0 up')
 
-can0 = can.interface.Bus(channel = 'can0', bustype = 'socketcan_ctypes')
+can0 = can.interface.Bus(channel = 'can0', bustype = 'socketcan')
 
 while True:
     msg = can0.recv(30.0)

--- a/For Linux Raspbian Ubuntu/software/python3/send.py
+++ b/For Linux Raspbian Ubuntu/software/python3/send.py
@@ -29,9 +29,9 @@ print(os.name)
 os.system('sudo ip link set can0 type can bitrate 1000000')
 os.system('sudo ifconfig can0 up')
 
-can0 = can.interface.Bus(channel = 'can0', bustype = 'socketcan_ctypes')
+can0 = can.interface.Bus(channel = 'can0', bustype = 'socketcan')
 
-msg = can.Message(arbitration_id=0x123, data=[0, 1, 2, 3,4,5,6], extended_id=False)
+msg = can.Message(arbitration_id=0x123, data=[0, 1, 2, 3,4,5,6], is_extended_id=False)
 can0.send(msg)
 
 os.system('sudo ifconfig can0 down')

--- a/For Linux Raspbian Ubuntu/software/python3/test.py
+++ b/For Linux Raspbian Ubuntu/software/python3/test.py
@@ -30,8 +30,8 @@ os.system('sudo ifconfig can0 up')
 os.system('sudo ip link set can1 type can bitrate 1000000')
 os.system('sudo ifconfig can1 up')
 
-can0 = can.interface.Bus(channel = 'can0', bustype = 'socketcan_ctypes')
-can1 = can.interface.Bus(channel = 'can1', bustype = 'socketcan_ctypes')
+can0 = can.interface.Bus(channel = 'can0', bustype = 'socketcan')
+can1 = can.interface.Bus(channel = 'can1', bustype = 'socketcan')
 
 def rs485_enable():
 ##  CAN0 SEND AND CAN1 RECEIVE    


### PR DESCRIPTION
'socketcan_ctypes' for bustype changed to just 'socketcan'
- See [https://python-can.readthedocs.io/en/master/interfaces/socketcan.html](https://python-can.readthedocs.io/en/master/interfaces/socketcan.html)

extended_id changed to is_extended_id
- See [https://python-can.readthedocs.io/en/master/message.html#can.Message](https://python-can.readthedocs.io/en/master/message.html#can.Message)